### PR TITLE
Add PPC/BTC explorer links

### DIFF
--- a/public/locales/en-US/translation.json
+++ b/public/locales/en-US/translation.json
@@ -123,6 +123,7 @@
     "generalFundPpcAddress": "General Fund - PPC Donation Address:",
     "generalFundBtcAddress": "General Fund - BTC Donation Address:",
     "exchangeBtcAddress": "Exchange Listing Fund - BTC Donation Address:",
+    "viewOnExplorer":"View on explorer",
     "contactUsTitle": "Contact Us",
     "addressCountry": "The Netherlands"
   },

--- a/src/pages/Foundation/Foundation.jsx
+++ b/src/pages/Foundation/Foundation.jsx
@@ -26,9 +26,9 @@ function Foundation() {
               <p>{t('foundationPage.technicalSupportText')}</p>
               <p>
               {t('foundationPage.generalFundPpcAddress')} <b>p92W3t7YkKfQEPDb7cG9jQ6iMh7cpKLvwK</b>
-              <a target="_blank" rel="noopener noreferrer" href="https://www.coinexplorer.net/PPC/address/p92W3t7YkKfQEPDb7cG9jQ6iMh7cpKLvwK">[ {t('foundationPage.viewOnExplorer')} ]</a><br />
+              <a target="_blank" rel="noopener noreferrer" href="https://www.coinexplorer.net/PPC/address/p92W3t7YkKfQEPDb7cG9jQ6iMh7cpKLvwK"> [ {t('foundationPage.viewOnExplorer')} ]</a><br />
               {t('foundationPage.generalFundBtcAddress')} <b>376NhxVL1LFBFndHNx9k7hvwvUzq6RZiPT</b>
-              <a target="_blank" rel="noopener noreferrer" href="https://www.coinexplorer.net/PPC/address/p92W3t7YkKfQEPDb7cG9jQ6iMh7cpKLvwK">[ {t('foundationPage.viewOnExplorer')} ]</a>
+              <a target="_blank" rel="noopener noreferrer" href="https://www.blockchain.com/fr/btc/address/376NhxVL1LFBFndHNx9k7hvwvUzq6RZiPT"> [ {t('foundationPage.viewOnExplorer')} ]</a>
               <br />
               {t('foundationPage.exchangeBtcAddress')} <b>3NtJTUyXuH8KJj4BXJJxtQS7SPnLNm711CM</b>
               </p>

--- a/src/pages/Foundation/Foundation.jsx
+++ b/src/pages/Foundation/Foundation.jsx
@@ -25,10 +25,10 @@ function Foundation() {
               <h2 className="title title--green title--left">{t('foundationPage.technicalSupportTitle')}</h2>
               <p>{t('foundationPage.technicalSupportText')}</p>
               <p>
-              {t('foundationPage.generalFundPpcAddress')} <b>p92W3t7YkKfQEPDb7cG9jQ6iMh7cpKLvwK</b>
-              <a target="_blank" rel="noopener noreferrer" href="https://www.coinexplorer.net/PPC/address/p92W3t7YkKfQEPDb7cG9jQ6iMh7cpKLvwK"> [ {t('foundationPage.viewOnExplorer')} ]</a><br />
-              {t('foundationPage.generalFundBtcAddress')} <b>376NhxVL1LFBFndHNx9k7hvwvUzq6RZiPT</b>
-              <a target="_blank" rel="noopener noreferrer" href="https://www.blockchain.com/fr/btc/address/376NhxVL1LFBFndHNx9k7hvwvUzq6RZiPT"> [ {t('foundationPage.viewOnExplorer')} ]</a>
+              {t('foundationPage.generalFundPpcAddress')} <b>p92W3t7YkKfQEPDb7cG9jQ6iMh7cpKLvwK </b>
+              <a target="_blank" rel="noopener noreferrer" href="https://chainz.cryptoid.info/ppc/address.dws?p92W3t7YkKfQEPDb7cG9jQ6iMh7cpKLvwK.htm">[ {t('foundationPage.viewOnExplorer')} ]</a><br />
+              {t('foundationPage.generalFundBtcAddress')} <b>376NhxVL1LFBFndHNx9k7hvwvUzq6RZiPT </b>
+              <a target="_blank" rel="noopener noreferrer" href="https://www.blockchain.com/fr/btc/address/376NhxVL1LFBFndHNx9k7hvwvUzq6RZiPT">[ {t('foundationPage.viewOnExplorer')} ]</a>
               <br />
               {t('foundationPage.exchangeBtcAddress')} <b>3NtJTUyXuH8KJj4BXJJxtQS7SPnLNm711CM</b>
               </p>

--- a/src/pages/Foundation/Foundation.jsx
+++ b/src/pages/Foundation/Foundation.jsx
@@ -25,8 +25,11 @@ function Foundation() {
               <h2 className="title title--green title--left">{t('foundationPage.technicalSupportTitle')}</h2>
               <p>{t('foundationPage.technicalSupportText')}</p>
               <p>
-              {t('foundationPage.generalFundPpcAddress')} <b>p92W3t7YkKfQEPDb7cG9jQ6iMh7cpKLvwK</b><br />
-              {t('foundationPage.generalFundBtcAddress')} <b>376NhxVL1LFBFndHNx9k7hvwvUzq6RZiPT</b><br />
+              {t('foundationPage.generalFundPpcAddress')} <b>p92W3t7YkKfQEPDb7cG9jQ6iMh7cpKLvwK</b>
+              <a target="_blank" rel="noopener noreferrer" href="https://www.coinexplorer.net/PPC/address/p92W3t7YkKfQEPDb7cG9jQ6iMh7cpKLvwK">[ {t('foundationPage.viewOnExplorer')} ]</a><br />
+              {t('foundationPage.generalFundBtcAddress')} <b>376NhxVL1LFBFndHNx9k7hvwvUzq6RZiPT</b>
+              <a target="_blank" rel="noopener noreferrer" href="https://www.coinexplorer.net/PPC/address/p92W3t7YkKfQEPDb7cG9jQ6iMh7cpKLvwK">[ {t('foundationPage.viewOnExplorer')} ]</a>
+              <br />
               {t('foundationPage.exchangeBtcAddress')} <b>3NtJTUyXuH8KJj4BXJJxtQS7SPnLNm711CM</b>
               </p>
             </div>


### PR DESCRIPTION
Added PPC/BTC explorer links for people to directly view instead of looking for explorer and copy/pasting. I noticed that exchangeBtcAddress isn't found on the BTC explorer that's why I didn't added as a link there.