### PR TITLE
Add Coinomi back as a wallet option.

### DIFF
--- a/src/pages/Wallet/Wallet.jsx
+++ b/src/pages/Wallet/Wallet.jsx
@@ -351,6 +351,17 @@ function Wallet() {
                 {t("walletPage.type2")}
               </div>
             </a>
+            <a href="https://www.coinomi.com/" className="blocks-list__block">
+              <h4 className="blocks-list__block__title">Coinomi</h4>
+              <img
+                className="blocks-list__block__img"
+                src="/img/wallets/coinomi.png"
+                alt=""
+              />
+              <div className="blocks-list__block__type">
+                {t("walletPage.type2")}
+              </div>
+            </a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
We used to have Coinomi as a wallet option but it was removed back when we reduced the required transaction fee: https://github.com/peercoin/peercoin.net/commit/ed3ac7633c333cfbc794795dbcb61797062d92c8

Coinomi does overcharge for transactions by default (it still uses the 0.01 per kilobyte minimum rule) but those are still valid transactions and the wallet works.