### PR TITLE
Removed empty renderHTML

### DIFF
--- a/src/pages/Wallet/Wallet.jsx
+++ b/src/pages/Wallet/Wallet.jsx
@@ -234,7 +234,6 @@ function Wallet() {
                     </ul>
                     <p>{renderHTML(t("walletPage.sectionLinux.text5"))}</p>
                     <p>{renderHTML(t("walletPage.sectionLinux.text6"))}</p>
-                    <p>{renderHTML(t("walletPage.sectionLinux.text7"))}</p>
                   </div>
                 </div>
               </Collapsible>


### PR DESCRIPTION
<img width="740" alt="Screenshot 2021-02-14 at 22 40 20" src="https://user-images.githubusercontent.com/4144334/107891308-a4835980-6f15-11eb-9730-83d5a1635bac.png">

Just noticed there was a small error at the end here, so have removed the empty section.