### PR TITLE
Added border-radius and a small amount of margin to mobile menu icon

### DIFF
--- a/src/components/Menu/Menu.scss
+++ b/src/components/Menu/Menu.scss
@@ -17,6 +17,11 @@
     display: none;
   }
 
+  @include viewports(up-to small) {
+    border-radius: 50%;
+    margin: 3px;
+  }
+
   img {
     width: 35px;
   }


### PR DESCRIPTION
Attempt to make mobile menu icon a bit less distracting.

BEFORE:
![before](https://user-images.githubusercontent.com/1542119/119235310-2517ae80-bb32-11eb-8f35-141ac45421b8.JPG)

AFTER:
![after](https://user-images.githubusercontent.com/1542119/119235312-2517ae80-bb32-11eb-8b64-fa3aeade8ea2.JPG)
