### PR TITLE
Smaller timeline and home-description images on medium screens

### DIFF
--- a/src/pages/Index/Index.scss
+++ b/src/pages/Index/Index.scss
@@ -244,7 +244,7 @@
       order: 1;
     }
 
-    @include viewports(up-to small) {
+    @include viewports(up-to medium) {
       width: 300px;
     }
   }
@@ -352,7 +352,7 @@
         img {
           width: 100%;
 
-          @include viewports(up-to small) {
+          @include viewports(up-to medium) {
             width: 250px;
           }
         }


### PR DESCRIPTION
Bumped smaller images rule up from small to medium on timeline and and home-description for better readability.




**BEFORE**:
![before1](https://user-images.githubusercontent.com/1542119/119235906-fea74280-bb34-11eb-8c02-1aad0ed4646a.JPG)
**AFTER**:
![after1](https://user-images.githubusercontent.com/1542119/119235905-fe0eac00-bb34-11eb-8d1a-a60a7571e280.JPG)

---

**BEFORE**:
![before2](https://user-images.githubusercontent.com/1542119/119235903-fe0eac00-bb34-11eb-9548-85bc25fce5a9.JPG)
**AFTER**:
![after2](https://user-images.githubusercontent.com/1542119/119235907-fea74280-bb34-11eb-87db-1122d8bec2a8.JPG)
