### PR TITLE
Remove U.S. language in iOS link

### DIFF
--- a/public/data/wallets.json
+++ b/public/data/wallets.json
@@ -44,7 +44,7 @@
           "subtitle": null
         },
         {
-          "url": "https://apps.apple.com/us/app/peercoin-wallet/id1571755170",
+          "url": "https://apps.apple.com/app/peercoin-wallet/id1571755170",
           "image": "/img/wallets/ios.png",
           "title": {
             "translated": false,


### PR DESCRIPTION
Remove U.S. language in iOS link